### PR TITLE
Disable annoying bot.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Outdated dependencies concern us only insofar as they have security issues and in those cases, we should be getting Dependabot alerts anyway.