### PR TITLE
Add in-memory certificate cache.

### DIFF
--- a/certcache.go
+++ b/certcache.go
@@ -3,8 +3,11 @@ package nitriding
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
 	"sync"
 
+	"github.com/mdlayher/vsock"
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -49,4 +52,32 @@ func (c *certCache) Delete(ctx context.Context, key string) error {
 
 	delete(c.cache, key)
 	return nil
+}
+
+func listenHTTP01(errChan chan error, mgr *autocert.Manager) {
+	// Let's Encrypt's HTTP-01 challenge requires a listener on port 80:
+	// https://letsencrypt.org/docs/challenge-types/#http-01-challenge
+	var l net.Listener
+	var err error
+
+	if inEnclave {
+		l, err = vsock.Listen(uint32(80), nil)
+		if err != nil {
+			errChan <- errHTTP01Failed
+			return
+		}
+		defer func() {
+			_ = l.Close()
+		}()
+	} else {
+		l, err = net.Listen("tcp", ":80")
+		if err != nil {
+			errChan <- errHTTP01Failed
+			return
+		}
+	}
+
+	elog.Print("Starting autocert listener.")
+	errChan <- nil
+	_ = http.Serve(l, mgr.HTTPHandler(nil))
 }

--- a/certcache.go
+++ b/certcache.go
@@ -1,0 +1,52 @@
+package nitriding
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+var (
+	errHTTP01Failed = errors.New("failed to listen for HTTP-01 challenge")
+)
+
+// certCache implements the autocert.Cache interface.
+type certCache struct {
+	sync.RWMutex
+	cache map[string][]byte
+}
+
+func newCertCache() *certCache {
+	return &certCache{
+		cache: make(map[string][]byte),
+	}
+}
+
+func (c *certCache) Get(ctx context.Context, key string) ([]byte, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	cert, exists := c.cache[key]
+	if !exists {
+		return nil, autocert.ErrCacheMiss
+	}
+	return cert, nil
+}
+
+func (c *certCache) Put(ctx context.Context, key string, data []byte) error {
+	c.Lock()
+	defer c.Unlock()
+
+	c.cache[key] = data
+	return nil
+}
+
+func (c *certCache) Delete(ctx context.Context, key string) error {
+	c.Lock()
+	defer c.Unlock()
+
+	delete(c.cache, key)
+	return nil
+}

--- a/certcache_test.go
+++ b/certcache_test.go
@@ -1,0 +1,67 @@
+package nitriding
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+func TestGet(t *testing.T) {
+	var err error
+	var key = "foo"
+	var expectedCert = []byte("bar")
+	c := newCertCache()
+
+	// Retrieve non-existing key.
+	_, err = c.Get(context.TODO(), key)
+	if !errors.Is(err, autocert.ErrCacheMiss) {
+		t.Fatalf("Expected error %v but got %v.", autocert.ErrCacheMiss, err)
+	}
+
+	// Retrieve existing key.
+	_ = c.Put(context.TODO(), key, expectedCert)
+	cert, err := c.Get(context.TODO(), key)
+	if err != nil {
+		t.Fatalf("Expected no error but got %v.", err)
+	}
+	if !bytes.Equal(expectedCert, cert) {
+		t.Fatalf("Expected value %s but got %s.", string(expectedCert), string(cert))
+	}
+}
+
+func TestPut(t *testing.T) {
+	var err error
+	var key = "foo"
+	var expectedCert = []byte("bar")
+	c := newCertCache()
+
+	if err = c.Put(context.TODO(), key, expectedCert); err != nil {
+		t.Fatalf("Expected no error but got %v.", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	var key = "foo"
+	var err error
+	c := newCertCache()
+
+	_ = c.Put(context.TODO(), key, []byte("bar"))
+	if err = c.Delete(context.TODO(), key); err != nil {
+		t.Fatalf("Expected no error but got %v.", err)
+	}
+	if len(c.cache) != 0 {
+		t.Fatal("Expected cache to be empty but it's not.")
+	}
+
+	// Try deleting the same element again.  This should not result in an error
+	// as our Delete never returns an error.
+	if err = c.Delete(context.TODO(), key); err != nil {
+		t.Fatalf("Expected no error but got %v.", err)
+	}
+	if len(c.cache) != 0 {
+		t.Fatal("Expected cache to be empty but it's not.")
+	}
+}

--- a/enclave.go
+++ b/enclave.go
@@ -309,10 +309,13 @@ func (e *Enclave) setupAcme() error {
 	var err error
 
 	elog.Printf("ACME hostname set to %s.", e.cfg.FQDN)
-	var cache autocert.Cache
-	// Only use the cache directory when we're *not* in an enclave.  There's no
-	// point in writing certificates to disk when in an enclave because the
-	// disk does not persist when the enclave shuts down.
+	// By default, we use an in-memory certificate cache.  We only use the
+	// directory cache when we're *not* in an enclave.  There's no point in
+	// writing certificates to disk when in an enclave because the disk does
+	// not persist when the enclave shuts down.  Besides, dealing with file
+	// permissions makes it more complicated to switch to an unprivileged user
+	// ID before execution.
+	var cache autocert.Cache = newCertCache()
 	if !inEnclave {
 		cache = autocert.DirCache(acmeCertCacheDir)
 	}

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -1,6 +1,7 @@
 package nitriding
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,5 +71,16 @@ func TestKeyMaterial(t *testing.T) {
 	}
 	if r != k {
 		t.Fatal("Retrieved key material is unexpected.")
+	}
+}
+
+func TestSetupAcme(t *testing.T) {
+	e := createEnclave()
+
+	// Our autocert code is difficult to test.  Simply run it until we hit the
+	// first error.  Better than testing nothing.
+	expectedErr := errHTTP01Failed
+	if err := e.setupAcme(); !errors.Is(err, expectedErr) {
+		t.Fatalf("Expected error %v but got %v.", expectedErr, err)
 	}
 }


### PR DESCRIPTION
This PR fixes a bug that I introduced in d21aa57ee065e11427dca6f9ac6ad0d7c969d9bb. When the goroutine later runs `cache.Get`, the code crashes if it's in an enclave because it's dereferencing a nil pointer. The PR adds an in-memory certificate cache and refactors `setupAcme`. It's difficult to test the function in its entirety but we can at least run it and make sure that the first error we get is as expected.