### PR TITLE
Fix two issues in key synchronization.

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -177,8 +177,8 @@ func (e *Enclave) Start() error {
 		e.router.Get(pathAttestation, getAttestationHandler(&e.certFpr))
 	}
 	e.router.Get(pathNonce, getNonceHandler(e))
-	e.router.Get(pathKeys, getKeysHandler(e, time.Now))
 	e.router.Get(pathRoot, getIndexHandler(e.cfg))
+	e.router.Post(pathKeys, getKeysHandler(e, time.Now))
 
 	// Tell Go's HTTP library to use SOCKS proxy for both HTTP and HTTPS.
 	if err := os.Setenv("HTTP_PROXY", e.cfg.SOCKSProxy); err != nil {

--- a/keysync_initiator.go
+++ b/keysync_initiator.go
@@ -141,6 +141,10 @@ func requestAttDoc(addr string, ourAttDoc []byte) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: expected status code %d but got %d", errStr, http.StatusOK, resp.StatusCode)
+	}
+
 	maxReadLen := base64.StdEncoding.EncodedLen(maxAttDocLen)
 	body, err := io.ReadAll(newLimitReader(resp.Body, maxReadLen))
 	if err != nil {


### PR DESCRIPTION
This commit fixes two more issues in how nitriding synchronizes key material:

1. We used to register a GET handler for key synchronization but the enclave would send a POST request. This commit replaces the GET with a POST header.
2. The requesting enclave would not check the HTTP status code after completing the POST request.

We need more test here, especially end-to-end tests. I'll work on that once https://github.com/brave/nitriding/issues/26 is merged.