### PR TITLE
Fix our use of the box API.

### DIFF
--- a/keysync_responder.go
+++ b/keysync_responder.go
@@ -107,8 +107,8 @@ func getKeysHandler(e *Enclave, curTime timeFunc) http.HandlerFunc {
 			return
 		}
 		var encrypted []byte
-		if _, err = box.SealAnonymous(
-			encrypted,
+		if encrypted, err = box.SealAnonymous(
+			nil,
 			jsonKeyMaterial,
 			theirBoxPubKey,
 			cryptoRand.Reader,


### PR DESCRIPTION
The encrypted blob is returned by the function; not written to the given 'out' byte slice.