### PR TITLE
Make various minor improvements.

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/hf/nitrite"
 	"github.com/hf/nsm"
@@ -78,6 +79,7 @@ func attestationHandler(hashes *AttestationHashes) http.HandlerFunc {
 			http.Error(w, errNoNonce, http.StatusBadRequest)
 			return
 		}
+		nonce = strings.ToLower(nonce)
 		if valid, _ := regexp.MatchString(nonceRegExp, nonce); !valid {
 			http.Error(w, errBadNonceFormat, http.StatusBadRequest)
 			return

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -89,7 +89,7 @@ func TestArePCRsIdentical(t *testing.T) {
 }
 
 func TestAttestationHashes(t *testing.T) {
-	e := createEnclave()
+	e := createEnclave(&defaultCfg)
 	appKeyHash := [sha256.Size]byte{1, 2, 3, 4, 5}
 
 	// Start the enclave.  This is going to initialize the hash over the HTTPS

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ var l = log.New(os.Stderr, "nitriding-cmd: ", log.Ldate|log.Ltime|log.LUTC|log.L
 func main() {
 	var fqdn, appURL, appWebSrv string
 	var extPort, intPort, hostProxyPort uint
-	var useACME bool
+	var useACME, waitForApp bool
 	var err error
 
 	flag.StringVar(&fqdn, "fqdn", "",
@@ -32,6 +32,8 @@ func main() {
 		"Port of proxy application running on EC2 host.")
 	flag.BoolVar(&useACME, "acme", false,
 		"Use Let's Encrypt's ACME to fetch HTTPS certificate.")
+	flag.BoolVar(&waitForApp, "wait-for-app", false,
+		"Start Internet-facing Web server only after application signals its readiness.")
 	flag.Parse()
 
 	if fqdn == "" {
@@ -53,6 +55,7 @@ func main() {
 		IntPort:       uint16(intPort),
 		HostProxyPort: uint32(hostProxyPort),
 		UseACME:       useACME,
+		WaitForApp:    waitForApp,
 	}
 	if appURL != "" {
 		u, err := url.Parse(appURL)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ var l = log.New(os.Stderr, "nitriding-cmd: ", log.Ldate|log.Ltime|log.LUTC|log.L
 func main() {
 	var fqdn, appURL, appWebSrv string
 	var extPort, intPort, hostProxyPort uint
-	var useACME, waitForApp bool
+	var useACME, waitForApp, debug bool
 	var err error
 
 	flag.StringVar(&fqdn, "fqdn", "",
@@ -34,6 +34,8 @@ func main() {
 		"Use Let's Encrypt's ACME to fetch HTTPS certificate.")
 	flag.BoolVar(&waitForApp, "wait-for-app", false,
 		"Start Internet-facing Web server only after application signals its readiness.")
+	flag.BoolVar(&debug, "debug", false,
+		"Print debug messages.")
 	flag.Parse()
 
 	if fqdn == "" {
@@ -56,6 +58,7 @@ func main() {
 		HostProxyPort: uint32(hostProxyPort),
 		UseACME:       useACME,
 		WaitForApp:    waitForApp,
+		Debug:         debug,
 	}
 	if appURL != "" {
 		u, err := url.Parse(appURL)

--- a/enclave.go
+++ b/enclave.go
@@ -153,11 +153,11 @@ func init() {
 
 	// Determine if we're inside an enclave.  Abort execution in the unexpected
 	// case that we cannot tell.
-	elog.Println("Determining whether we're running inside an enclave.")
 	inEnclave, err = randseed.InEnclave()
 	if err != nil {
 		elog.Fatalf("Failed to determine if we're inside an enclave: %v", err)
 	}
+	elog.Printf("We're running inside an enclave: %v", inEnclave)
 }
 
 // NewEnclave creates and returns a new enclave with the given config.

--- a/enclave.go
+++ b/enclave.go
@@ -133,6 +133,9 @@ type Config struct {
 	// before launching the Internet-facing Web server.  Set this flag if your
 	// application takes a while to bootstrap and you don't want to risk
 	// inconsistent state when syncing, or unexpected attestation documents.
+	// If set, your application must make the following request when ready:
+	//
+	//     GET http://127.0.0.1:{IntPort}/enclave/ready
 	WaitForApp bool
 }
 

--- a/enclave.go
+++ b/enclave.go
@@ -128,6 +128,12 @@ type Config struct {
 	// if the enclave application exposes an HTTP server.  Non-HTTP enclave
 	// applications can ignore this.
 	AppWebSrv *url.URL
+
+	// WaitForApp instructs nitriding to wait for the application's signal
+	// before launching the Internet-facing Web server.  Set this flag if your
+	// application takes a while to bootstrap and you don't want to risk
+	// inconsistent state when syncing, or unexpected attestation documents.
+	WaitForApp bool
 }
 
 // Validate returns an error if required fields in the config are not set.
@@ -261,12 +267,13 @@ func startWebServers(e *Enclave) error {
 	elog.Printf("Starting public (%s) and private (%s) Web server.", e.pubSrv.Addr, e.privSrv.Addr)
 
 	go e.privSrv.ListenAndServe() //nolint:errcheck
-
-	// Don't launch our Internet-facing Web server until the application
-	// signalled that it's ready.
 	go func() {
-		<-e.ready
-		elog.Println("Application signalled that it's ready.  Starting public Web server.")
+		// If desired, don't launch our Internet-facing Web server until the
+		// application signalled that it's ready.
+		if e.cfg.WaitForApp {
+			<-e.ready
+			elog.Println("Application signalled that it's ready.  Starting public Web server.")
+		}
 		e.pubSrv.ListenAndServeTLS("", "") //nolint:errcheck
 	}()
 

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-var defaultCfg = &Config{
+var defaultCfg = Config{
 	FQDN:          "example.com",
 	ExtPort:       50000,
 	IntPort:       50001,
@@ -13,10 +13,11 @@ var defaultCfg = &Config{
 	Debug:         false,
 	FdCur:         1024,
 	FdMax:         4096,
+	WaitForApp:    true,
 }
 
-func createEnclave() *Enclave {
-	e, err := NewEnclave(defaultCfg)
+func createEnclave(cfg *Config) *Enclave {
+	e, err := NewEnclave(cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -47,14 +48,14 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestGenSelfSignedCert(t *testing.T) {
-	e := createEnclave()
+	e := createEnclave(&defaultCfg)
 	if err := e.genSelfSignedCert(); err != nil {
 		t.Fatalf("Failed to create self-signed certificate: %s", err)
 	}
 }
 
 func TestKeyMaterial(t *testing.T) {
-	e := createEnclave()
+	e := createEnclave(&defaultCfg)
 	k := struct{ Foo string }{"foobar"}
 
 	if _, err := e.KeyMaterial(); err != errNoKeyMaterial {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -186,7 +186,10 @@ func TestReadiness(t *testing.T) {
 	defer e.Stop() //nolint:errcheck
 
 	// Make sure that the Internet-facing Web server is already running because
-	// we didn't ask nitriding to wait for the application.
+	// we didn't ask nitriding to wait for the application.  Give the Web
+	// server 100 milliseconds to start.  This isn't great but there's no
+	// convenient way to check if the Web server is already running.
+	time.Sleep(time.Millisecond * 100)
 	nitridingSrv := fmt.Sprintf("https://127.0.0.1:%d", e.cfg.ExtPort)
 	if _, err := http.Get(nitridingSrv + pathRoot); err != nil {
 		t.Fatalf("Expected no error but got %v", err)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -203,10 +203,13 @@ func TestReadiness(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected no error but got %v", err)
 			}
-			if resp.StatusCode == http.StatusOK {
-				return
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("Expected status code %d but got %d.",
+					http.StatusOK, resp.StatusCode)
 			}
+			return
 		}
+		t.Fatal("Unable to talk to Internet-facing Web server.")
 	}(t, u)
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -197,7 +197,9 @@ func TestReadiness(t *testing.T) {
 }
 
 func TestReadyHandler(t *testing.T) {
-	e := createEnclave(&defaultCfg)
+	cfg := defaultCfg
+	cfg.WaitForApp = true
+	e := createEnclave(&cfg)
 	if err := e.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -222,7 +222,7 @@ func TestReadyHandler(t *testing.T) {
 	// Check if the Internet-facing Web server is running.
 	nitridingSrv := fmt.Sprintf("https://127.0.0.1:%d", e.cfg.ExtPort)
 	_, err := http.Get(nitridingSrv + pathRoot)
-	if !strings.Contains(err.Error(), "connection refused") {
+	if !errors.Is(err, syscall.ECONNREFUSED) {
 		t.Fatal("Expected 'connection refused'.")
 	}
 	signalReady(t, e)

--- a/keysync_responder_test.go
+++ b/keysync_responder_test.go
@@ -24,7 +24,7 @@ func queryHandler(handler http.HandlerFunc, path string, reader io.Reader) *http
 }
 
 func TestNonceHandler(t *testing.T) {
-	enclave := createEnclave()
+	enclave := createEnclave(&defaultCfg)
 	res := queryHandler(nonceHandler(enclave), pathNonce, bytes.NewReader([]byte{}))
 
 	// Did the operation succeed?
@@ -57,7 +57,11 @@ func TestNonceHandlerIfErr(t *testing.T) {
 		cryptoRead = rand.Read
 	}()
 
-	res := queryHandler(nonceHandler(createEnclave()), pathNonce, bytes.NewReader([]byte{}))
+	res := queryHandler(
+		nonceHandler(createEnclave(&defaultCfg)),
+		pathNonce,
+		bytes.NewReader([]byte{}),
+	)
 
 	// Did the operation fail?
 	if res.StatusCode != http.StatusInternalServerError {
@@ -74,7 +78,7 @@ func TestNonceHandlerIfErr(t *testing.T) {
 
 func TestRespSyncHandlerForBadReqs(t *testing.T) {
 	var res *http.Response
-	enclave := createEnclave()
+	enclave := createEnclave(&defaultCfg)
 
 	// Send non-Base64 bogus data.
 	res = queryHandler(respSyncHandler(enclave), pathSync, strings.NewReader("foobar!"))
@@ -87,7 +91,7 @@ func TestRespSyncHandlerForBadReqs(t *testing.T) {
 
 func TestRespSyncHandler(t *testing.T) {
 	var res *http.Response
-	enclave := createEnclave()
+	enclave := createEnclave(&defaultCfg)
 	enclave.nonceCache.Add(initAttInfo.nonce.B64())
 
 	// Mock functions for our tests to pass.
@@ -104,7 +108,7 @@ func TestRespSyncHandler(t *testing.T) {
 
 func TestRespSyncHandlerDoS(t *testing.T) {
 	var res *http.Response
-	enclave := createEnclave()
+	enclave := createEnclave(&defaultCfg)
 
 	// Send more data than the handler should be willing to read.
 	maxSize := base64.StdEncoding.EncodedLen(maxAttDocLen)


### PR DESCRIPTION
This PR makes the following improvements:

* Add the `-wait-for-app` command line switch which instructs nitriding to wait for the enclave application before spinning up its Internet-facing Web server. If the flag is not set (which is the default), nitriding spins up the Web server right away.
* Add the `-debug` command line switch which instructs nitriding to print debug messages to stderr.
* Make a log message more useful.
* Allow both upper and lower case nonces.
* Mitigate a race condition in a unit test.