### PR TITLE
Build a static executable

### DIFF
--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all lint clean
 
 binary = nitriding
-godeps = *.go ../*.go ../go.mod ../go.sum
+godeps = *.go ../*.go ../go.mod ../go.sum Makefile
 
 all: lint $(binary)
 

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -9,7 +9,7 @@ lint:
 	golangci-lint run
 
 $(binary): $(godeps)
-	go build -o $(binary)
+	CGO_ENABLED=0 go build -o $(binary)
 
 clean:
 	rm -f $(binary)


### PR DESCRIPTION
Build the `nitriding` cmd with cgo disabled.
    
Since we're no longer linking to any C libraries, build a completely static executable to avoid dependencies on a particular libc. This makes it easier to use the daemon on either alpine (musl libc) or fuller-featured environments.
