### PR TITLE
Minor streamline tweaks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@ func main() {
 		"Code repository of the enclave application (e.g., \"github.com/foo/bar\").")
 	flag.StringVar(&appWebSrv, "appwebsrv", "",
 		"Enclave-internal HTTP server of the enclave application (e.g., \"http://127.0.0.1:8081\").")
-	flag.UintVar(&extPort, "extport", 8443,
+	flag.UintVar(&extPort, "extport", 443,
 		"Nitriding's VSOCK-facing HTTPS port.  Must match port forwarding rules on EC2 host.")
 	flag.UintVar(&intPort, "intport", 8080,
 		"Nitriding's enclave-internal HTTP port.  Only used by the enclave application.")

--- a/enclave.go
+++ b/enclave.go
@@ -79,7 +79,7 @@ type Config struct {
 	FQDN string
 
 	// ExtPort contains the VSOCK-facing TCP port that the Web server should
-	// listen on, e.g.  8443.  This port is not *directly* reachable by the
+	// listen on, e.g. 443.  This port is not *directly* reachable by the
 	// Internet but the EC2 host's proxy *does* forward Internet traffic to
 	// this port.  This field is required.
 	ExtPort uint16

--- a/example/Makefile
+++ b/example/Makefile
@@ -22,7 +22,7 @@ kill:
 	@if [ "$(ENCLAVE_ID)" != "null" ]; then nitro-cli terminate-enclave --enclave-id $(ENCLAVE_ID); fi
 
 run:
-	nitro-cli run-enclave --cpu-count 2 --memory 4000 --enclave-cid 4 --eif-path $(enclave_image) --debug-mode
+	nitro-cli run-enclave --cpu-count 2 --memory 512 --enclave-cid 4 --eif-path $(enclave_image) --debug-mode
 	nitro-cli console --enclave-id $$(nitro-cli describe-enclaves | jq -r '.[0].EnclaveID')
 
 clean:

--- a/example/start.sh
+++ b/example/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/nitriding -fqdn example.com  -extport 8443  -intport 8080 &
+/nitriding -fqdn example.com  -extport 443  -intport 8080 &
 echo "[sh] Started nitriding."
 
 sleep 1

--- a/handlers.go
+++ b/handlers.go
@@ -64,7 +64,7 @@ func reqSyncHandler(e *Enclave) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		// The 'addr' parameter must have the following form:
-		// https://example.com:8443
+		// https://example.com:443
 		addrs, ok := q["addr"]
 		if !ok {
 			http.Error(w, errNoAddr.Error(), http.StatusBadRequest)


### PR DESCRIPTION
- Use port 443 for the nitriding proxy external interface. There's no reason to use an unprivileged port inside the enclave, and if the application is doing something more complicated, they'll be editing the command line anyway.
- Only request 512 MB for the example application so it works out-of-the-box without bumping the default allocation limit.