### PR TITLE
Don't record vcs info when building the nitriding executable.

### DIFF
--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -9,7 +9,7 @@ lint:
 	golangci-lint run
 
 $(binary): $(godeps)
-	CGO_ENABLED=0 go build -o $(binary)
+	CGO_ENABLED=0 go build -buildvcs=false -o $(binary)
 
 clean:
 	rm -f $(binary)


### PR DESCRIPTION
Since release 1.18 go has included version control system metadata in builds. This isn't bad per-se but it does complicate reproducibility since building from a git checkout produces different results to building from a source snapshot of the same source code.

More practically, this is preventing a clean build with our Dockerfile under the `kaniko` container image tool, perhaps by conveying a partial environment from the host repository.

Pass `-buildvcs=false` when building `nitriding` to avoid these issues.