### PR TITLE
Add command line flag to run enclave application.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,47 +51,8 @@ Nitriding provides the following features:
 To learn more about nitriding's trust assumptions, architecture, and build
 system, take a look at our [research paper](https://arxiv.org/abs/2206.04123).
 
-## Usage
-
-To use nitriding, the following steps are necessary:
-
-1. Make sure that your enclave application supports
-   [reproducible builds](https://reproducible-builds.org);
-   otherwise, users won't be able to verify your enclave image.
-
-2. Set up
-   [this proxy application](https://github.com/containers/gvisor-tap-vsock/tree/main/cmd/gvproxy)
-   on the EC2 host.
-
-3. Bundle your application and nitriding together in a Dockerfile.  The
-   nitriding stand-alone executable must be invoked first, followed by your
-   application.  To build the nitriding executable, run `make cmd/nitriding`.
-   (Then, run `./cmd/nitriding -help` to see a list of command line options.)
-   For reproducible Docker images, we recommend
-   [kaniko](https://github.com/GoogleContainerTools/kaniko)
-   and
-   [ko](https://github.com/ko-build/ko) (for Go applications only).
-
-4. Once your application is done bootstrapping, it must let nitriding know, so
-   it can start the Internet-facing Web server that handles remote attestation
-   and other tasks.  To do so, the application must issue an HTTP GET request to
-   `http://127.0.0.1:8080/enclave/ready`.  The handler ignores URL parameters
-   and responds with a status code 200 if the request succeeded.  Note that the
-   port in this example, 8080, is controlled by nitriding's `-intport` command
-   line flag.
-
-Take a look at [this example application](example/) to learn how nitriding works
-in practice.
-
-## Development
-
-To test and lint the code, run:
-
-```
-make
-```
-
 ## More documentation
 
+* [How to use nitriding](doc/usage.md)
 * [System architecture](doc/architecture.md)
 * [Example application](example/)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint clean
+.PHONY: all lint test clean
 
 binary = nitriding
 godeps = *.go ../*.go ../go.mod ../go.sum Makefile
@@ -7,6 +7,9 @@ all: lint $(binary)
 
 lint:
 	golangci-lint run
+
+test: $(godeps)
+	@go test -cover ./...
 
 $(binary): $(godeps)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -buildvcs=false -o $(binary)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,14 +123,14 @@ func runAppCommand(appCmd string, stdoutFunc, stderrFunc func(string)) {
 	if err != nil {
 		l.Fatalf("Failed to obtain stderr pipe for enclave application: %v", err)
 	}
-	go printOutput(stderr, stderrFunc, "stderr")
+	go forwardOutput(stderr, stderrFunc, "stderr")
 
 	// Print the enclave application's stdout.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		l.Fatalf("Failed to obtain stdout pipe for enclave application: %v", err)
 	}
-	go printOutput(stdout, stdoutFunc, "stdout")
+	go forwardOutput(stdout, stdoutFunc, "stdout")
 
 	if err := cmd.Start(); err != nil {
 		l.Fatalf("Failed to start enclave application: %v", err)
@@ -142,9 +142,9 @@ func runAppCommand(appCmd string, stdoutFunc, stderrFunc func(string)) {
 	l.Println("Enclave application exited.")
 }
 
-// printOutput continuously reads from the given Reader until an EOF occurs.
+// forwardOutput continuously reads from the given Reader until an EOF occurs.
 // Each newly read line is passed to the given function f.
-func printOutput(readCloser io.ReadCloser, f func(string), output string) {
+func forwardOutput(readCloser io.ReadCloser, f func(string), output string) {
 	r := bufio.NewReader(readCloser)
 	for {
 		b, err := r.ReadBytes(0x0a) // Read until we see a newline.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bufio"
+	"errors"
 	"flag"
+	"io"
 	"log"
 	"math"
 	"net/url"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/brave/nitriding"
 )
@@ -13,7 +18,7 @@ import (
 var l = log.New(os.Stderr, "nitriding-cmd: ", log.Ldate|log.Ltime|log.LUTC|log.Lshortfile)
 
 func main() {
-	var fqdn, appURL, appWebSrv string
+	var fqdn, appURL, appWebSrv, appCmd string
 	var extPort, intPort, hostProxyPort uint
 	var useACME, waitForApp, debug bool
 	var err error
@@ -24,6 +29,8 @@ func main() {
 		"Code repository of the enclave application (e.g., \"github.com/foo/bar\").")
 	flag.StringVar(&appWebSrv, "appwebsrv", "",
 		"Enclave-internal HTTP server of the enclave application (e.g., \"http://127.0.0.1:8081\").")
+	flag.StringVar(&appCmd, "appcmd", "",
+		"Launch enclave application via the given command.")
 	flag.UintVar(&extPort, "extport", 443,
 		"Nitriding's VSOCK-facing HTTPS port.  Must match port forwarding rules on EC2 host.")
 	flag.UintVar(&intPort, "intport", 8080,
@@ -84,6 +91,71 @@ func main() {
 		l.Fatalf("Enclave terminated: %v", err)
 	}
 
-	// Block on this read forever.
-	<-make(chan struct{})
+	// Nitriding supports two ways of starting the enclave application:
+	//
+	// 1) Nitriding spawns the enclave application itself, and waits for it
+	//    to terminate.
+	//
+	// 2) The enclave application is started by a shell script (which also
+	//    starts nitriding).  In this case, we simply block forever.
+	if appCmd != "" {
+		f := func(s string) {
+			l.Printf("Application says: %s", s)
+		}
+		runAppCommand(appCmd, f, f)
+	} else {
+		// Block forever.
+		<-make(chan struct{})
+	}
+	l.Println("Exiting nitriding.")
+}
+
+// runAppCommand (i) runs the given command, (ii) waits until the command
+// finished execution, and (iii) in the meanwhile prints the command's stdout
+// and stderr.
+func runAppCommand(appCmd string, stdoutFunc, stderrFunc func(string)) {
+	l.Printf("Invoking the enclave application.")
+	args := strings.Split(appCmd, " ")
+	cmd := exec.Command(args[0], args[1:]...)
+
+	// Print the enclave application's stderr.
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		l.Fatalf("Failed to obtain stderr pipe for enclave application: %v", err)
+	}
+	go printOutput(stderr, stderrFunc, "stderr")
+
+	// Print the enclave application's stdout.
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		l.Fatalf("Failed to obtain stdout pipe for enclave application: %v", err)
+	}
+	go printOutput(stdout, stdoutFunc, "stdout")
+
+	if err := cmd.Start(); err != nil {
+		l.Fatalf("Failed to start enclave application: %v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		l.Fatalf("Enclave application exited with non-0 exit code: %v", err)
+	}
+	l.Println("Enclave application exited.")
+}
+
+// printOutput continuously reads from the given Reader until an EOF occurs.
+// Each newly read line is passed to the given function f.
+func printOutput(readCloser io.ReadCloser, f func(string), output string) {
+	r := bufio.NewReader(readCloser)
+	for {
+		b, err := r.ReadBytes(0x0a) // Read until we see a newline.
+		if errors.Is(err, io.EOF) {
+			l.Printf("Encountered EOF in %s.  Returning.", output)
+			return
+		}
+		if err != nil {
+			l.Printf("Failed to read from enclave application's %s: %v", output, err)
+			return
+		}
+		f(string(b))
+	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSpawnAppProcess(t *testing.T) {
+	expected := []string{"1", "2", "3"}
+	output := []string{}
+	f := func(s string) {
+		output = append(output, strings.TrimSpace(s))
+	}
+	dummy := func(string) {}
+
+	runAppCommand("seq 1 3", f, dummy)
+	if len(output) != len(expected) {
+		t.Fatalf("Expected slice length %d but got %d.", len(expected), len(output))
+	}
+
+	for i := range output {
+		if output[i] != expected[i] {
+			t.Fatalf("Expected element at index %d to be %s but got %s.", i, expected[i], output[i])
+		}
+	}
+}

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -40,7 +40,7 @@ nitriding.  The following steps are necessary.
    an application of kaniko.
 
 3. Bundle the freshly-compiled nitriding and your enclave application together
-   in a Dockerfile.  The nitriding stand-alone executable must be invoked
+   with a Dockerfile.  The nitriding stand-alone executable must be invoked
    first, followed by your application.  There are two ways to go about this.
    First, you can create a shell script that first starts nitriding in the
    background, followed by the enclave application.  [Here's an

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,69 @@
+## Usage
+
+This document explains how you can build your enclave application on top of
+nitriding.  The following steps are necessary.
+
+1. Make sure that your enclave application supports [reproducible
+   builds](https://reproducible-builds.org); otherwise, users won't be able to
+   verify your enclave image.  Both Rust and Go support reproducible builds
+   although some effort may be necessary to get there.
+   [Nitriding's Makefile](../cmd/Makefile) shows how one can build a Go program
+   reproducibly.
+
+2. Set up
+   [this proxy application](https://github.com/containers/gvisor-tap-vsock/tree/main/cmd/gvproxy)
+   on the EC2 host.  Run it as follows:
+   ```
+   gvproxy -listen vsock://:1024 -listen unix:///tmp/network.sock
+   ```
+   Next, tell the proxy application to forward port 443 to nitriding.
+   ```
+   curl \
+     --unix-socket /tmp/network.sock \
+     http:/unix/services/forwarder/expose \
+     -X POST \
+     -d '{"local":":443","remote":"192.168.127.2:443"}'
+   ```
+   In case you're wondering, 192.168.127.2 is nitriding's static IP address in
+   the private network between gvproxy and nitriding.  Does your enclave
+   application expose any other ports?  If so, you have to forward these ports
+   too.
+
+3. Build the nitriding executable by running `make cmd/nitriding`.
+   (Then, run `./cmd/nitriding -help` to see a list of command line options.)
+   For reproducible Docker images, we recommend
+   [kaniko](https://github.com/GoogleContainerTools/kaniko)
+   or
+   [ko](https://github.com/ko-build/ko) (for Go applications only).
+   Take a look at [this
+   Makefile](https://github.com/brave/star-randsrv/blob/main/Makefile) to see
+   an application of kaniko.
+
+3. Bundle the freshly-compiled nitriding and your enclave application together
+   in a Dockerfile.  The nitriding stand-alone executable must be invoked
+   first, followed by your application.  There are two ways to go about this.
+   First, you can create a shell script that first starts nitriding in the
+   background, followed by the enclave application.  [Here's an
+   example](../example/start.sh).  Second, you can tell nitriding to start your
+   enclave application for you:
+   ```
+   nitriding -appcmd "my-enclave-app -s foo"
+   ```
+   This instructs nitriding to invoke the command `my-enclave-app -s foo`.
+   Nitriding keeps running as long as my-enclave-app is running.
+
+4. There's one more thing, but only if you invoked nitriding with the flag
+   `-wait-for-app`: Once your application is done bootstrapping, it must let
+   nitriding know, so it can start the Internet-facing Web server that handles
+   remote attestation and other tasks.  To do so, the application must issue an
+   HTTP GET request to `http://127.0.0.1:8080/enclave/ready`.  The handler
+   ignores URL parameters and responds with a status code 200 if the request
+   succeeded.  Note that the port in this example, 8080, is controlled by
+   nitriding's `-intport` command line flag.  Ignore this paragraph if you did
+   not use `-wait-for-app`.
+
+Finally, take a look at
+[this example application](example/)
+or 
+[this production application](https://github.com/brave/star-randsrv/)
+to learn how one can build on top of nitriding.


### PR DESCRIPTION
This commit adds a new command line flag that instructs nitriding to run the given enclave application.  Nitriding then blocks until the command finishes (if ever) and prints both the command's stdout and stderr.

This feature has the advantage that one does not need a shell script to start both nitriding and the enclave application, meaning that it's now easier to build very slim Docker images that only contain a statically-compiled nitriding and enclave application.

This fixes https://github.com/brave/nitriding/issues/58.