### PR TITLE
Make nitriding's reverse proxy faster.

### DIFF
--- a/bufferpool.go
+++ b/bufferpool.go
@@ -1,0 +1,39 @@
+package nitriding
+
+import (
+	"sync"
+)
+
+// bufSize represents the buffer size for our reverse proxy.  It's identical to
+// the buffer size used in Go's reverse proxy implementation:
+// https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/net/http/httputil/reverseproxy.go;l=634
+const bufSize = 32 * 1024
+
+// bufPool implements the httputil.BufferPool interface.  The implementation is
+// based on sync.Pool.
+type bufPool struct {
+	sync.Pool
+}
+
+func newBufPool() *bufPool {
+	return &bufPool{
+		Pool: sync.Pool{
+			New: func() any {
+				// The Pool's New function should generally only return pointer
+				// types, since a pointer can be put into the return interface
+				// value without an allocation:
+				s := make([]byte, bufSize)
+				return &s
+			},
+		},
+	}
+}
+
+func (p *bufPool) Get() []byte {
+	s := p.Pool.Get()
+	return *s.(*[]byte)
+}
+
+func (p *bufPool) Put(buf []byte) {
+	p.Pool.Put(&buf)
+}

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -1,0 +1,14 @@
+package nitriding
+
+import "testing"
+
+func TestBufPool(t *testing.T) {
+	p := newBufPool()
+	s1 := p.Get()
+	p.Put(s1)
+	s2 := p.Get()
+
+	if len(s1) != len(s2) {
+		t.Fatalf("Byte slices have different lengths (%d vs %d).", len(s1), len(s2))
+	}
+}

--- a/enclave.go
+++ b/enclave.go
@@ -185,6 +185,13 @@ func NewEnclave(cfg *Config) (*Enclave, error) {
 		ready:      make(chan bool),
 	}
 
+	// Increase the maximum number of idle connections per host.  This is
+	// critical to boosting the requests per second that our reverse proxy can
+	// sustain.  See the following comment for more details:
+	// https://github.com/brave/nitriding/issues/45#issuecomment-1526012586
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = 100
+	http.DefaultTransport.(*http.Transport).MaxIdleConns = 100
+
 	if cfg.Debug {
 		e.pubSrv.Handler.(*chi.Mux).Use(middleware.Logger)
 		e.privSrv.Handler.(*chi.Mux).Use(middleware.Logger)

--- a/enclave.go
+++ b/enclave.go
@@ -209,7 +209,7 @@ func NewEnclave(cfg *Config) (*Enclave, error) {
 	// server.
 	if cfg.AppWebSrv != nil {
 		e.revProxy = httputil.NewSingleHostReverseProxy(cfg.AppWebSrv)
-		e.pubSrv.Handler.(*chi.Mux).Handle(pathProxy, proxyHandler(e))
+		e.pubSrv.Handler.(*chi.Mux).Handle(pathProxy, e.revProxy)
 	}
 
 	return e, nil

--- a/enclave.go
+++ b/enclave.go
@@ -216,6 +216,7 @@ func NewEnclave(cfg *Config) (*Enclave, error) {
 	// server.
 	if cfg.AppWebSrv != nil {
 		e.revProxy = httputil.NewSingleHostReverseProxy(cfg.AppWebSrv)
+		e.revProxy.BufferPool = newBufPool()
 		e.pubSrv.Handler.(*chi.Mux).Handle(pathProxy, e.revProxy)
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -44,14 +44,6 @@ func rootHandler(cfg *Config) http.HandlerFunc {
 	}
 }
 
-// proxyHandler returns an HTTP handler that proxies HTTP requests to the
-// enclave-internal HTTP server of our enclave application.
-func proxyHandler(e *Enclave) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		e.revProxy.ServeHTTP(w, r)
-	}
-}
-
 // reqSyncHandler returns a handler that lets the enclave application request
 // state synchronization, which copies the given remote enclave's state into
 // our state.


### PR DESCRIPTION
This PR makes two changes:

1. Increase `MaxIdleConnsPerHost` and `MaxIdleConns`. This made a substantial difference in the requests per second that a simple enclave Web service can sustain.
2. Add a buffer pool. This made no noticeable difference but there's a chance that it makes a difference when deploying the STAR randomness server.